### PR TITLE
smarty inheritance_merge_compiled_includes = false

### DIFF
--- a/src/Hamlet/Template/SmartyRenderer.php
+++ b/src/Hamlet/Template/SmartyRenderer.php
@@ -20,6 +20,7 @@ class SmartyRenderer implements TemplateRendererInterface
         $smarty = new Smarty();
         $smarty->setCacheDir(sys_get_temp_dir());
         $smarty->setCompileDir(sys_get_temp_dir());
+        $smarty->inheritance_merge_compiled_includes = false;
         if ($this->pluginDirectoryPath != null) {
             $smarty->addPluginsDir($this->pluginDirectoryPath);
         }


### PR DESCRIPTION
Fix for 'variable template file names not allow within {block} tags'
error.
